### PR TITLE
Update make rules with proper format

### DIFF
--- a/rulesSources.mk
+++ b/rulesSources.mk
@@ -6,31 +6,31 @@
 #      *                                                                *
 #      ******************************************************************
 
-.F90.o:	Makefile
+%.o: %.F90
 	$(FF90) $(FF90_ALL_FLAGS) -c $< -o $(OBJDIR)/$(@F)
 	@echo
 	@echo "        --- Compiled $*.F90 successfully ---"
 	@echo
 
-.f90.o:	Makefile
+%.o: %.f90
 	$(FF90) $(FF90_ALL_FLAGS) -c $< -o $(OBJDIR)/$(@F)
 	@echo
 	@echo "        --- Compiled $*.f90 successfully ---"
 	@echo
 
-.f.o:	Makefile
+%.o: %.f
 	$(FF90) $(FF90_ALL_FLAGS) -c $< -o $(OBJDIR)/$(@F)
 	@echo
 	@echo "        --- Compiled $*.f successfully ---"
 	@echo
 
-.F.o:	Makefile
+%.o: %.F
 	$(FF90) $(FF90_ALL_FLAGS) -c $< -o $(OBJDIR)/$(@F)
 	@echo
 	@echo "        --- Compiled $*.f successfully ---"
 	@echo
 
-.c.o:   Makefile
+%.o: %.c
 	$(CC) $(CC_ALL_FLAGS) -c $< -o $(OBJDIR)/$(@F)
 	@echo
 	@echo "        --- Compiled $*.c successfully ---"


### PR DESCRIPTION
## Purpose
This PR updates the make rules to
- support the newer pattern rules format. 
- suppress the `warning: ignoring prerequisites on suffix rule definition` which newer versions of `make` (4.3) generate

## Expected time until merged
No rush, but should be quick to test and merge.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Make sure code compiles using the updated make rules.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
