### PR TITLE
Allow GCC 10+ compilation

### DIFF
--- a/common_real.mk
+++ b/common_real.mk
@@ -40,7 +40,7 @@ MAKE_CLEAN_ARGUMENTS = *~ *.o *.mod *.il *.stb c_* *.a
 #      ******************************************************************
 
 # Check compiler and version and add flags if needed
-EXTRA_FF77_FLAGS = $(shell bash ../../config/compilerCheck.sh mpifort)
+EXTRA_FF77_FLAGS = $(shell bash ../../config/compilerCheck.sh $(FF90))
 
 FF77_ALL_FLAGS = -I$(MODDIR) \
 		$(CGNS_INCLUDE_FLAGS) \

--- a/common_real.mk
+++ b/common_real.mk
@@ -39,9 +39,13 @@ MAKE_CLEAN_ARGUMENTS = *~ *.o *.mod *.il *.stb c_* *.a
 #      *                                                                *
 #      ******************************************************************
 
+# Check compiler and version and add flags if needed
+EXTRA_FF77_FLAGS = $(shell bash ../../config/compilerCheck.sh mpifort)
+
 FF77_ALL_FLAGS = -I$(MODDIR) \
 		$(CGNS_INCLUDE_FLAGS) \
-		$(FF77_FLAGS)
+		$(FF77_FLAGS) \
+		$(EXTRA_FF77_FLAGS)
 
 FF90_ALL_FLAGS = -I$(MODDIR) \
 		$(CGNS_INCLUDE_FLAGS) \

--- a/config/compilerCheck.sh
+++ b/config/compilerCheck.sh
@@ -11,8 +11,8 @@ FFLAGS=""
 
 # Allow argument mismatch for gfortran >= 10
 
-# NOTE: The reason for adding this flag is because Tapenade 3.16's ADFirstAidKIt is not compliant with GCC 10+.
-# This should be removed once Tapenade fixes this or removes the ADFirstAidKIt.
+# NOTE: The reason for adding this flag is because Tapenade 3.16's ADFirstAidKit is not compliant with GCC 10+.
+# This should be removed once Tapenade fixes this or removes the ADFirstAidKit.
 
 fc=$("$FF90" --version 2>&1 | grep -i 'gnu')
 if [ ! -z "$fc" ]; then

--- a/config/compilerCheck.sh
+++ b/config/compilerCheck.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Need one argument at least
+if [ -z $1 ]; then
+    echo "$0 needs to be called with the compiler name as an argument"; exit 1
+fi
+
+# Initialize variables
+FF90=$1
+FFLAGS=""
+
+# Allow argument mismatch for gfortran >= 10
+
+# NOTE: The reason for adding this flag is because Tapenade 3.16's ADFirstAidKIt is not compliant with GCC 10+.
+# This should be removed once Tapenade fixes this or removes the ADFirstAidKIt.
+
+fc=$("$FF90" --version 2>&1 | grep -i 'gnu')
+if [ ! -z "$fc" ]; then
+    # Get the GNU compiler version
+    version=$("$FF90" -v 2>&1 | grep 'gcc version' | cut -d' ' -f3)
+    if [ ! -z "$version" ]; then
+      # Get the major version
+      version_major=`echo $version | cut -f1 -d.`
+    fi
+
+    if [ $version_major -ge 10 ]; then
+        FFLAGS="-fallow-argument-mismatch"
+    fi
+fi
+
+# Print at end to add to the makefile
+echo "$FFLAGS"


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
In #16, I updated the AD code and ADFirstAidKit to use Tapenade 3.16 instead of 3.10. However, the newer ADFirstAidKit is not compatible with GCC 10+ because of type mismatches. ~~I reverted the ADFirstAidKit files to Tapenade 3.10 in this PR. The actual AD code is still generated with Tapenade 3.16.~~

I added `-fallow-argument-mismatch` to the  F77 gfortran flags to allow compilation with GCC 10+.


## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
2-3 days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
