### PR TITLE
Make Intel config compiler check more robust

### DIFF
--- a/config/defaults/config_LINUX_INTEL.mk
+++ b/config/defaults/config_LINUX_INTEL.mk
@@ -7,7 +7,7 @@ PMAKE = make -j 4
 
 # ------- Define the MPI Compilers--------------------------------------
 ifdef I_MPI_ROOT # Using Intel MPI
-  ICC_EXISTS := $(shell command -v icc)
+  ICC_EXISTS := $(shell command -v icc;) # Note that ";" is there to avoid make shell optimization, otherwise the shell command may fail
 
   ifdef ICC_EXISTS
     # icc only exists on older Intel versions


### PR DESCRIPTION
## Purpose
Previous PR #30 updated the Intel config for the new compilers. However, nightly builds are [failing](https://github.com/mdolab/docker/actions/runs/9074000144/job/24932039405#step:11:2295) on the `u20-intel-impi-latest` image with the following error. This was not detected in previous PR tests, since we do not run tests on this image. 

```
#27 3.661 make[1]: Entering directory '/home/***/repos/pysurf'
#27 3.661 mkdir -p obj
#27 3.663 mkdir -p mod
#27 3.665 ln -sf config/config.mk config.mk
#27 3.666 ln -sf common_real.mk common.mk
#27 3.668 making discretesurf in src/common
#27 3.668 
#27 3.670 make[2]: Entering directory '/home/***/repos/pysurf/src/common'
#27 3.670 make[2]: command: Command not found
#27 3.671 make -j 4 precision.o
#27 3.673 make[3]: Entering directory '/home/***/repos/pysurf/src/common'
#27 3.673 make[3]: command: Command not found
#27 3.674 mpiifx -I../../mod -I/home/***/packages/CGNS-4.4.0/opt-intel/include -fPIC -r8 -O2 -g -std08 -c precision.F90 -o ../../obj/precision.o
#27 3.674 make[3]: mpiifx: Command not found
#27 3.674 make[3]: *** [../../rulesSources.mk:10: precision.o] Error 127
#27 3.675 make[3]: Leaving directory '/home/***/repos/pysurf/src/common'
#27 3.675 make[2]: *** [Makefile:22: all] Error 2
#27 3.675 make[2]: Leaving directory '/home/***/repos/pysurf/src/common'
#27 3.675 make[1]: *** [Makefile:46: discretesurf] Error 1
#27 3.675 make[1]: Leaving directory '/home/***/repos/pysurf'
#27 3.675 make: *** [Makefile:11: default] Error 1
```

The same error is also appearing in the build output of https://github.com/mdolab/docker/pull/266, for example see [here](https://github.com/mdolab/docker/actions/runs/9069190501/job/24918184607?pr=266#step:11:844) (copied here for archiving), but works as the correct Intel compiler is set in the catch-all `else` block.
```
#23 0.741 Cloning into 'pyspline'...
#23 1.753 make[1]: Entering directory '/home/***/repos/pyspline'
#23 1.753 mkdir -p obj
#23 1.756 ln -sf config/config.mk config.mk
#23 1.759 making module in src/
#23 1.759 
#23 1.761 make[2]: Entering directory '/home/***/repos/pyspline/src'
#23 1.762 make[2]: command: Command not found
#23 1.764 make precision.o adtProjections.o
```

The issue is related to some shell optimization in `make` and built-in functions (see [here for details](https://stackoverflow.com/questions/17547625/how-to-use-shell-builtin-function-from-a-makefile/17550243#17550243)) not running a proper shell. 

There are a couple of approaches we can take
1. add a shell specific character to invoke a proper shell (done in this PR)
2. change `command` to `which`, but the latter is not a built-in function and thus invokes a proper shell.

I am fine with either option, but I suggest we converge here before opening PRs on all other repos

## Expected time until merged
ASAP as nightly tests are failing

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Test building (running `make`) with and without this bug fix

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
