### PR TITLE
Use CGNS data types

### DIFF
--- a/src/CGNSInterface/cgnsInterface.F90
+++ b/src/CGNSInterface/cgnsInterface.F90
@@ -286,7 +286,8 @@ contains
 
         ! CGNS Variables
         integer(kind=intType) :: i, j, k, m, l, istart, iend, localsize, iProc
-        integer(kind=intType) :: ierr, base, dims(3), iZone
+        integer(kind=intType) :: ierr, base, iZone
+        integer(cgsize_t) :: dims(3), elementDataSize, eBeg, eEnd
         integer(kind=intType) :: nNodes, nCells
         integer(kind=intType) :: tmpSym, nSymm
         character(len=32) :: zoneName, bocoName, famName
@@ -296,11 +297,11 @@ contains
         integer(kind=intType) :: nVertices, nElements, nzones
         integer(kind=intType) :: zoneType, dataType, sec, type
         integer(kind=intType) :: nSections, nElem, nConn
-        integer(kind=intType) :: eBeg, eEnd, nBdry, parentFlag
+        integer(kind=intType) :: nBdry, parentFlag
         integer(kind=intType) :: bocoType, ptsettype, nbcelem
         integer(kind=intType) :: normalIndex, normalListFlag
         integer(kind=intType) :: nDataSet, tmpInt(2)
-        integer(kind=intType) :: elementDataSize, curElement, eCount, nPnts
+        integer(kind=intType) :: curElement, eCount, nPnts
         real(kind=realType), dimension(:), allocatable :: coorX, coorY, coorZ
         integer(kind=intType), dimension(:), allocatable :: tmpConn
         real(kind=realType), dimension(:, :), allocatable, target :: allNodes


### PR DESCRIPTION
## Purpose
I had problems compiling this on our cluster. Turns out, the data type for CGNS-calls is hard coded. This PR fixes this by using the data type defined by CGNS.

I only looked at places, where my compilation failed. This problem might still exist in places where my CGNS install happened to have the 'correct' data type.

## Expected time until merged
1 week

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
It compiles now

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
